### PR TITLE
add a setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+curl -fsL "https://raw.githubusercontent.com/unifi-utilities/unifios-utilities/HEAD/on-boot-script/remote_install.sh" | /bin/sh
+cp 10-monitor-ppp-mtu.sh /data/on_boot.d/
+chmod +x /data/on_boot.d/10-monitor-ppp-mtu.sh
+mkdir -p /data/change-ppp-mtu
+cp 11-change-ppp-mtu.sh /data/change-ppp-mtu/
+chmod +x /data/change-ppp-mtu/11-change-ppp-mtu.sh


### PR DESCRIPTION
this grabs the on-boot-script and moves everything into the correct directories and makes them executable

I made this for myself for convenience. figured that I would share. I did notice that the readme says to put things at /mnt/data  but when i installed on-boot it told me to put things in /data instead.  I am using a udm-pro perhaps this is a difference between the udm-pro and the udm-se.  if so I can modify this script to check for which of the two the script is being run on and move things accordingly. I thought one of the maintainers with a udm-se might be able to confirm my theory